### PR TITLE
update to v5.0.17.5498

### DIFF
--- a/eid-belgium.nuspec
+++ b/eid-belgium.nuspec
@@ -4,7 +4,7 @@
   <metadata>
     <id>eid-belgium</id>
     <title>Belgium e-ID middleware</title>
-    <version>4.1.2</version>
+    <version>5.0.17.5498</version>
     <authors>ZETES S.A., Fedict</authors>
     <owners>chocolatey</owners>
     <summary>Middleware for the Belgian electronic identity card</summary>


### PR DESCRIPTION
Packages have been updated. Updates are needed for latest cards per [this news article](https://www.vrt.be/vrtnws/nl/2021/09/16/nieuwste-identiteitskaarten-vaak-onleesbaar-update-moet-problee/). Thanks for maintaining this.